### PR TITLE
[Update #35] toolbar button size

### DIFF
--- a/loc-tan/Toolbar/View/ToolBarItemView.swift
+++ b/loc-tan/Toolbar/View/ToolBarItemView.swift
@@ -36,10 +36,10 @@ class ToolBarItemView: UIButton {
         
         NSLayoutConstraint.activate([
             widthAnchor.constraint(equalTo: heightAnchor),
-            imageView!.centerXAnchor.constraint(equalTo: centerXAnchor),
-            imageView!.centerYAnchor.constraint(equalTo: centerYAnchor),
-            imageView!.widthAnchor.constraint(equalTo: widthAnchor),
-            imageView!.heightAnchor.constraint(equalTo: heightAnchor)
+            imageView!.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            imageView!.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
+            imageView!.leftAnchor.constraint(equalTo: leftAnchor, constant: 5),
+            imageView!.rightAnchor.constraint(equalTo: rightAnchor, constant: -5),
         ])
     }
 

--- a/loc-tan/Toolbar/View/ToolBarModeSwitcher.swift
+++ b/loc-tan/Toolbar/View/ToolBarModeSwitcher.swift
@@ -30,10 +30,10 @@ class ToolBarModeSwitcher: UIButton {
         
         NSLayoutConstraint.activate([
             widthAnchor.constraint(equalTo: heightAnchor),
-            imageView!.centerXAnchor.constraint(equalTo: centerXAnchor),
-            imageView!.centerYAnchor.constraint(equalTo: centerYAnchor),
-            imageView!.widthAnchor.constraint(equalTo: widthAnchor),
-            imageView!.heightAnchor.constraint(equalTo: heightAnchor)
+            imageView!.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            imageView!.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
+            imageView!.leftAnchor.constraint(equalTo: leftAnchor, constant: 5),
+            imageView!.rightAnchor.constraint(equalTo: rightAnchor, constant: -5),
         ])
     }
     

--- a/loc-tan/ViewController.swift
+++ b/loc-tan/ViewController.swift
@@ -30,10 +30,10 @@ class ViewController: UIViewController {
             let toolbarView = toolbarViewController.view!
             toolbarContainer.addSubview(toolbarView)
             NSLayoutConstraint.activate([
-                toolbarView.topAnchor.constraint(equalTo: toolbarContainer.topAnchor, constant: 5),
-                toolbarView.bottomAnchor.constraint(equalTo: toolbarContainer.bottomAnchor, constant: -5),
-                toolbarView.leftAnchor.constraint(equalTo: toolbarContainer.leftAnchor, constant: 5),
-                toolbarView.rightAnchor.constraint(equalTo: toolbarContainer.rightAnchor, constant: -5),
+                toolbarView.topAnchor.constraint(equalTo: toolbarContainer.topAnchor),
+                toolbarView.bottomAnchor.constraint(equalTo: toolbarContainer.bottomAnchor),
+                toolbarView.leftAnchor.constraint(equalTo: toolbarContainer.leftAnchor),
+                toolbarView.rightAnchor.constraint(equalTo: toolbarContainer.rightAnchor),
             ])
             toolbarViewController.didMove(toParent: self)
         }


### PR DESCRIPTION
- ツールバーのマージンを削除
- ツールバーボタン内のアイコン画像にマージンを設定
- これにより、アイコンサイズはそのままに、当たり判定を拡大